### PR TITLE
Report natural 20 roll

### DIFF
--- a/content.js
+++ b/content.js
@@ -17,19 +17,49 @@ function sendDiceResult(mutations, observer) {
 			let diceResults = document.body.querySelectorAll(".dice_result__total-result")
 			let latestDiceResult = diceResults.item(diceResults.length - 1)
 			if (latestDiceResult !== null) {
-				sendMessageToDiscordChannel(latestDiceResult.innerText)
+				let message = createMessage(latestDiceResult.innerText)
+				sendMessageToDiscordChannel(message)
 				break;
 			}
 		}
 	}
 }
 
-function sendMessageToDiscordChannel(diceResult) {
-	let message = {"content": `${characterName()} rolled a ${diceResult}`}
+function sendMessageToDiscordChannel(message) {
+	let content = {"content": message}
 	let headers = {"content-type": "application/json"}
-	fetch(webhookUrl, {"method": "POST", "headers": headers, "body": JSON.stringify(message)})
+	fetch(webhookUrl, {"method": "POST", "headers": headers, "body": JSON.stringify(content)})
+}
+
+function createMessage(diceResult) {
+	if (isNatural20AttackRoll() && !isRollWithDisadvantage()) {
+		return `${characterName()} rolled a natural 20!`
+	}
+
+	return `${characterName()} rolled a ${diceResult}`
 }
 
 function characterName() {
 	return document.body.querySelector(".ddbc-character-name ").innerText
+}
+
+function isNatural20AttackRoll() {
+	let diceBreakdowns = document.body.querySelectorAll(".dice_result__info__breakdown")
+	let latestDiceBreakdown = diceBreakdowns.item(diceBreakdowns.length - 1)
+	let isNatural20 = latestDiceBreakdown.innerText.includes("20")
+
+	if (!isNatural20) {
+		return false;
+	}
+
+	let diceRollTypes = document.body.querySelectorAll(".dice_result__rolltype")
+	let latestDiceRollType = diceRollTypes.item(diceRollTypes.length -1)
+	let isAttackRoll = latestDiceRollType.classList.contains("rolltype_tohit")
+	return isNatural20 && isAttackRoll
+}
+
+function isRollWithDisadvantage() {
+	let diceResultContainers = document.body.querySelectorAll(".dice_result__total-container")
+	let latestDiceResultContainer = diceResultContainers.item(diceResultContainers.length - 1)
+	return latestDiceResultContainer.innerText.includes("DIS")
 }


### PR DESCRIPTION
When a player rolls a 20 on an attack roll (without disadvantage) then send a message to the channel saying that the character rolled a natural 20.

According to the Player's Handbook for 5th Edition, [only attack rolls](https://rpg.stackexchange.com/a/108079) and death saving throws benefit from a natural 20. And when [rolling with disadvantage](https://rpg.stackexchange.com/a/72046), you must take the lower roll.

This does not take into account the scenario where the player rolls with disadvantage but rolls two 20s.