### PR TITLE
Add character image and roll info to message

### DIFF
--- a/content.js
+++ b/content.js
@@ -29,7 +29,7 @@ function sendMessageToDiscordChannel(diceResult) {
 		"embeds": [{
 			"title": createMessageTitle(),
 			"description": createMessageDescription(diceResult),
-			"color": 12923185,
+			"color": createMessageColor(),
 			"thumbnail": createMessageThumbnail(),
 			"footer": createMessageFooter()
 		}]
@@ -48,6 +48,13 @@ function createMessageDescription(diceResult) {
 	let diceBreakdowns = document.body.querySelectorAll(".dice_result__info__breakdown")
 	let latestDiceBreakdown = last(diceBreakdowns).innerText
 	return `${latestDiceBreakdown} = \`${diceResult}\``
+}
+
+function createMessageColor() {
+	let diceRollTypes = document.body.querySelectorAll(".dice_result__rolltype")
+	let latestDiceRollType = last(diceRollTypes)
+	let rgbColor = getComputedStyle(latestDiceRollType).color.slice(4, -1).split(", ")
+	return rgbToDecimal(rgbColor[0], rgbColor[1], rgbColor[2])
 }
 
 function createMessageThumbnail() {
@@ -71,4 +78,8 @@ function last(nodeList) {
 
 function capitalize(words) {
 	return words.replace(/\w\S*/g, word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+}
+
+function rgbToDecimal(red, green, blue) {
+	return parseInt(red << 16) + parseInt(green << 8) + parseInt(blue)
 }

--- a/content.js
+++ b/content.js
@@ -25,11 +25,50 @@ function sendDiceResult(mutations, observer) {
 }
 
 function sendMessageToDiscordChannel(diceResult) {
-	let message = {"content": `${characterName()} rolled a ${diceResult}`}
+	let message = {
+		"embeds": [{
+			"title": createMessageTitle(),
+			"description": createMessageDescription(diceResult),
+			"color": 12923185,
+			"thumbnail": createMessageThumbnail(),
+			"footer": createMessageFooter()
+		}]
+	}
 	let headers = {"content-type": "application/json"}
 	fetch(webhookUrl, {"method": "POST", "headers": headers, "body": JSON.stringify(message)})
 }
 
+function createMessageTitle() {
+	let rollDescriptions = document.body.querySelectorAll(".dice_result__info__title")
+	let latestRollDescription = last(rollDescriptions).innerText
+	return `${characterName()} rolled ${capitalize(latestRollDescription)}`
+}
+
+function createMessageDescription(diceResult) {
+	let diceBreakdowns = document.body.querySelectorAll(".dice_result__info__breakdown")
+	let latestDiceBreakdown = last(diceBreakdowns).innerText
+	return `${latestDiceBreakdown} = \`${diceResult}\``
+}
+
+function createMessageThumbnail() {
+	let portrait = document.body.querySelector(".ddbc-character-avatar__portrait")
+	let portraitUrl = portrait.style.backgroundImage.slice(5, -2)
+	return {"url": portraitUrl}
+}
+
+function createMessageFooter() {
+	let diceNotations = document.body.querySelectorAll(".dice_result__info__dicenotation")
+	return {"text": last(diceNotations).innerText}
+}
+
 function characterName() {
 	return document.body.querySelector(".ddbc-character-name ").innerText
+}
+
+function last(nodeList) {
+	return nodeList.item(nodeList.length - 1)
+}
+
+function capitalize(words) {
+	return words.replace(/\w\S*/g, word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
 }


### PR DESCRIPTION
Creates a Discord message with an embed object which will display the character's profile image, the dice roll description, breakdown, result, and notation. Also takes the color of the roll type from D&D Beyond and use it as the message's color.

Providing a profile image and roll description allows the results to be more readable when multiple players are rolling at once. Displaying the dice roll breakdown also provides more flexibility to the players and DM because it allows them to apply house rules to things like natural 20s and 1s. Also, taking the color creates more visual parity between the message and the character sheet and allows players to more easily discern between rolls.

Closes #2 and closes #3 since the dice breakdown in the message will show players not just the result, but also when a natural 20 or a natural 1 is rolled.

| Before | After |
|-------|-------|
| <img width="403" alt="Screen Shot 2020-07-30 at 3 54 56 PM" src="https://user-images.githubusercontent.com/821855/88973897-670ef580-d27d-11ea-9d2b-8280e8103180.png"> | <img width="415" alt="Screen Shot 2020-07-30 at 3 54 48 PM" src="https://user-images.githubusercontent.com/821855/88973921-7130f400-d27d-11ea-83db-1388cfd87c8a.png"> |


