### PR TITLE
feat(hotreload): refreshes options page on change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5758,6 +5758,12 @@
                 "mkdirp": "^0.5.1"
             }
         },
+        "ws": {
+            "version": "7.3.1",
+            "resolved": "https://trendkite.jfrog.io/trendkite/api/npm/libs-frontend/ws/-/ws-7.3.1.tgz",
+            "integrity": "sha1-0FR79n985PEqct/jEmLGjX3FUcg=",
+            "dev": true
+        },
         "yaml": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "sass-loader": "^10.0.3",
         "style-loader": "^2.0.0",
         "webpack": "^5.1.3",
-        "webpack-cli": "^4.0.0"
+        "webpack-cli": "^4.0.0",
+        "ws": "^7.3.1"
     },
     "husky": {
         "hooks": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,11 @@ const theme = createMuiTheme({
     },
 })
 
+// TODO: only execute this code when in development
+const ws = new WebSocket('ws://localhost:1337')
+ws.addEventListener('error', (e) => console.log('WEBSOCKET ERROR ----', e))
+ws.addEventListener('message', () => window.location.reload())
+
 const App = () => (
     <ThemeProvider theme={theme}>
         <CssBaseline />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,17 @@
 const webpack = require('webpack')
 const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const WebSocket = require('ws')
+
+const wss = new WebSocket.Server({ port: 1337 })
+
+wss.on('connection', (ws) => {
+    ws.on('message', (data) => {
+        wss.clients.forEach((client) => {
+            client.send(data)
+        })
+    })
+})
 
 const config = {
     entry: ['./src/index.js'],
@@ -30,6 +41,17 @@ const config = {
             template: './src/index.html',
             filename: 'options.html',
         }),
+        {
+            apply: (compiler) => {
+                compiler.hooks.afterEmit.tap(
+                    'AfterEmitPlugin',
+                    (compilation) => {
+                        const ws = new WebSocket('ws://localhost:1337')
+                        ws.on('open', () => ws.send('build complete'))
+                    }
+                )
+            },
+        },
     ],
 }
 


### PR DESCRIPTION
This resolves #12 

* The `npm run dev` command now starts a websocket server on port 1337. 
* We emit a build complete event when the new files have been written to the fs
* A ws client listens for messages on 1337
* When it gets one it refreshes the page

There is literally nothing fancy about it other than just having it refresh the page for you and it's only on the options page. 

### Concerns
- [ ] As proposed, if the user's machine is _not_ running a websocket server on 1337 then they'll see an error in the console. The app functions normally besides this. Blocker?
- [ ] Should the build listener be inserted into `content.js` as well? This would cause the DDB page to refresh when changes occur on the `content.js` file.